### PR TITLE
Fix rsync errors and add CI

### DIFF
--- a/.github/actions/install_apt_packages/action.yml
+++ b/.github/actions/install_apt_packages/action.yml
@@ -1,0 +1,33 @@
+name: install_apt_packages
+description: 'Install specified APT packages'
+
+inputs:
+  packages:
+    description: 'A space-separated list of APT packages to install.'
+    required: true
+  use-sudo:
+    description: 'Whether to use sudo for installation commands.'
+    required: false
+    default: 'true'
+  use-update:
+    description: 'Whether to run apt-get update before installing packages.'
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Install APT packages
+      run: |
+        if [ "${{ inputs.use-sudo }}" = "true" ]; then
+          SUDO="sudo"
+        else
+          SUDO=""
+        fi
+
+        if [ "${{ inputs.use-update }}" = "true" ]; then
+          $SUDO apt-get update
+        fi
+
+        $SUDO apt-get install -y ${{ inputs.packages }}
+      shell: bash

--- a/.github/actions/install_python_packages/action.yml
+++ b/.github/actions/install_python_packages/action.yml
@@ -1,0 +1,40 @@
+name: install_python_packages
+description: 'Install specified Python packages in a virtual environment'
+
+inputs:
+  packages:
+    description: 'A space-separated list of Python packages to install.'
+    required: true
+  python-version:
+    description: 'The Python version to use (e.g., 3.12).'
+    required: true
+  venv-path:
+    description: 'The path where the virtual environment should be created.'
+    required: false
+    default: '.venv'
+  use-sudo:
+    description: 'Whether to use sudo for installation commands.'
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+
+    - name: Install required APT packages
+      uses: micro-ROS/micro_ros_tivac_launchpad_app/.github/actions/install_apt_packages@hotfix/fix-rsync-errors
+      with:
+        packages: "python${{ inputs.python-version }}-venv"
+        use-sudo: ${{ inputs.use-sudo }}
+        use-update: "false"
+
+    - name: Setup environment
+      run: |
+        python${{ inputs.python-version }} -m venv ${{ inputs.venv-path }}
+        echo PATH=${GITHUB_WORKSPACE}/.venv/bin:$PATH >> $GITHUB_ENV
+      shell: bash
+
+    - name: Install Python packages
+      run: |
+        pip install ${{ inputs.packages }}
+      shell: bash

--- a/.github/actions/install_sdk/action.yml
+++ b/.github/actions/install_sdk/action.yml
@@ -1,0 +1,57 @@
+name: install_sdk
+description: Generate the TivaWare for C Series SDK files
+
+inputs:
+  sdk_version:
+    description: 'The SW-TM4C SDK version to install (See https://www.ti.com/tool/SW-TM4C#downloads).'
+    required: true
+  install_path:
+    description: 'The path where the SDK should be installed.'
+    required: true
+  force_reinstall:
+    description: 'Force reinstallation even if the SDK is already installed.'
+    required: false
+    default: 'false'
+  use-sudo:
+    description: 'Whether to use sudo for installation commands.'
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+
+    - name: Install APT packages
+      uses: micro-ROS/micro_ros_tivac_launchpad_app/.github/actions/install_apt_packages@hotfix/fix-rsync-errors
+      with:
+        packages: "curl p7zip"
+        use-sudo: ${{ inputs.use-sudo }}
+        use-update: "false"
+
+    - name: Install TivaWare SDK files
+      run: |
+        SDK_VERSION="${{ inputs.sdk_version }}"
+        INSTALL_PATH="${{ inputs.install_path }}"
+        FORCE_REINSTALL="${{ inputs.force_reinstall }}"
+        SDK_EXE="SDK-${SDK_VERSION}.exe"
+        SDK_URL="https://dr-download.ti.com/software-development/software-development-kit-sdk/MD-oCcDwnGrsI/${SDK_VERSION}/SW-TM4C-${SDK_VERSION}.exe"
+
+        if [ -d "$INSTALL_PATH" ] && [ "$FORCE_REINSTALL" != "true" ]; then
+          echo "SDK already installed at $INSTALL_PATH. Skipping download and installation."
+          exit 0
+        fi
+
+        mkdir -p "$INSTALL_PATH"
+        cd "$INSTALL_PATH"
+
+        echo "Downloading TivaWare SDK version $SDK_VERSION..."
+        curl -L -o "$SDK_EXE" "$SDK_URL"
+
+        echo "Extracting SDK..."
+        7z x "$SDK_EXE" -o"$INSTALL_PATH"
+
+        echo "Cleaning up..."
+        rm "$SDK_EXE"
+
+        echo "TivaWare SDK version $SDK_VERSION installed at $INSTALL_PATH."
+      shell: bash

--- a/.github/workflows/humble-ci.yml
+++ b/.github/workflows/humble-ci.yml
@@ -1,0 +1,14 @@
+name: CI (Humble)
+
+on:
+  push:
+    branches: [ humble ]
+  pull_request:
+    branches: [ humble ]
+
+jobs:
+  build:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      os: ubuntu-22.04
+      branch: humble

--- a/.github/workflows/humble-ci.yml
+++ b/.github/workflows/humble-ci.yml
@@ -11,4 +11,4 @@ jobs:
     uses: ./.github/workflows/reusable-ci.yml
     with:
       os: ubuntu-22.04
-      branch: humble
+      branch: ${{ github.ref }}

--- a/.github/workflows/jazzy-ci.yml
+++ b/.github/workflows/jazzy-ci.yml
@@ -11,4 +11,4 @@ jobs:
     uses: ./.github/workflows/reusable-ci.yml
     with:
       os: ubuntu-24.04
-      branch: jazzy
+      branch: ${{ github.ref }}

--- a/.github/workflows/jazzy-ci.yml
+++ b/.github/workflows/jazzy-ci.yml
@@ -1,0 +1,14 @@
+name: CI (Jazzy)
+
+on:
+  push:
+    branches: [ jazzy ]
+  pull_request:
+    branches: [ jazzy ]
+
+jobs:
+  build:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      os: ubuntu-24.04
+      branch: jazzy

--- a/.github/workflows/kilted.ci.yml
+++ b/.github/workflows/kilted.ci.yml
@@ -1,0 +1,14 @@
+name: CI (Kilted)
+
+on:
+  push:
+    branches: [ kilted ]
+  pull_request:
+    branches: [ kilted ]
+
+jobs:
+  build:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      os: ubuntu-24.04
+      branch: kilted

--- a/.github/workflows/kilted.ci.yml
+++ b/.github/workflows/kilted.ci.yml
@@ -11,4 +11,4 @@ jobs:
     uses: ./.github/workflows/reusable-ci.yml
     with:
       os: ubuntu-24.04
-      branch: kilted
+      branch: ${{ github.ref }}

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -1,0 +1,28 @@
+name: Nightly CI (all distros)
+
+on:
+  schedule:
+    - cron: '59 23 * * *'  # Runs every day at 23:59 UTC
+  workflow_dispatch:
+
+jobs:
+  humble-ci:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      branch: humble
+      os: ubuntu-22.04
+  jazzy-ci:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      branch: jazzy
+      os: ubuntu-24.04
+  kilted-ci:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      branch: kilted
+      os: ubuntu-24.04
+  rolling-ci:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      branch: rolling
+      os: ubuntu-24.04

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -1,0 +1,57 @@
+name: Reusable CI Workflow
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: "The OS to use for the workflow"
+        required: true
+        type: string
+      branch:
+        description: "The branch to use for the workflow"
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ${{ inputs.os }}
+    strategy:
+      fail-fast: false
+    steps:
+
+      - name: Install APT packages
+        uses: micro-ROS/micro_ros_tivac_launchpad_app/.github/actions/install_apt_packages@hotfix/fix-rsync-errors
+        with:
+          packages: "build-essential cmake gcc-arm-none-eabi"
+          use-sudo: "true"
+          use-update: "true"
+
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install required python packages
+        uses: micro-ROS/micro_ros_tivac_launchpad_app/.github/actions/install_python_packages@hotfix/fix-rsync-errors
+        with:
+          packages: "catkin_pkg lark-parser empy colcon-common-extensions"
+          python-version: "3.12"
+          use-sudo: "true"
+
+      - name: Sync repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.branch }}
+          submodules: recursive
+
+      - name: Install TivaWare SDK
+        uses: micro-ROS/micro_ros_tivac_launchpad_app/.github/actions/install_sdk@hotfix/fix-rsync-errors
+        with:
+          sdk_version: "2.1.4.178"
+          install_path: "${{ github.workspace }}/tivaware_c_series"
+          force_reinstall: "false"
+          use-sudo: "true"
+
+      - name: Build project
+        run: make -j$(nproc)
+        shell: bash

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install APT packages
         uses: micro-ROS/micro_ros_tivac_launchpad_app/.github/actions/install_apt_packages@hotfix/fix-rsync-errors
         with:
-          packages: "build-essential cmake gcc-arm-none-eabi"
+          packages: "build-essential cmake gcc-arm-none-eabi rsync"
           use-sudo: "true"
           use-update: "true"
 

--- a/.github/workflows/rolling-ci.yml
+++ b/.github/workflows/rolling-ci.yml
@@ -1,0 +1,14 @@
+name: CI (Rolling)
+
+on:
+  push:
+    branches: [ rolling ]
+  pull_request:
+    branches: [ rolling ]
+
+jobs:
+  build:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      os: ubuntu-24.04
+      branch: rolling

--- a/.github/workflows/rolling-ci.yml
+++ b/.github/workflows/rolling-ci.yml
@@ -11,4 +11,4 @@ jobs:
     uses: ./.github/workflows/reusable-ci.yml
     with:
       os: ubuntu-24.04
-      branch: rolling
+      branch: ${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ This example application has been tested in TI Tiva™ C Series TM4C123GXL Launc
 
 ## Dependencies
 
-This component needs `rsync` to setup Micro-ROS:
+This component needs the following packages to setup Micro-ROS:
 
 ```bash
-sudo apt install -y rsync
+sudo apt install -y rsync pip git gcc-arm-none-eabi cmake
 ```
 
 This component needs `colcon` and other Python 3 packages in order to build micro-ROS packages:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ This example application has been tested in TI Tiva™ C Series TM4C123GXL Launc
 
 ## Dependencies
 
+This component needs `rsync` to setup Micro-ROS:
+
+```bash
+sudo apt install -y rsync
+```
+
 This component needs `colcon` and other Python 3 packages in order to build micro-ROS packages:
 
 ```bash

--- a/microros/generate_microros_library.sh
+++ b/microros/generate_microros_library.sh
@@ -137,7 +137,6 @@ pushd $INSTALL_DIR/micro_ros_src > /dev/null
     INCLUDE_ROS2_PACKAGES=$(colcon list | awk '{print $1}' | awk -v d=" " '{s=(NR==1?s:s d)$0}END{print s}')
 popd > /dev/null
 
-apt -y install rsync
 for var in ${INCLUDE_ROS2_PACKAGES}; do
     if [ -d "$INSTALL_DIR/include/${var}/${var}/" ]; then
         rsync -r "$INSTALL_DIR/include/${var}/${var}/" "$INSTALL_DIR/include/${var}/"

--- a/microros/generate_microros_library.sh
+++ b/microros/generate_microros_library.sh
@@ -139,8 +139,10 @@ popd > /dev/null
 
 apt -y install rsync
 for var in ${INCLUDE_ROS2_PACKAGES}; do
-    rsync -r $INSTALL_DIR/include/${var}/${var}/* $INSTALL_DIR/include/${var}/
-    rm -rf $INSTALL_DIR/include/${var}/${var}/
+    if [ -d "$INSTALL_DIR/include/${var}/${var}/" ]; then
+        rsync -r "$INSTALL_DIR/include/${var}/${var}/" "$INSTALL_DIR/include/${var}/"
+        rm -rf "$INSTALL_DIR/include/${var}/${var}/"
+    fi
 done
 
 # Print compiler info


### PR DESCRIPTION
# Main changes

- Solve some rsync errors encountered when running `generate_microros_library.sh`. Some colcon packages don't follow the <package_name>/<package_name> directory schema to store the header files, so `rsync` command only runs if the directory exists.
- Add CI for each supported distro (PR + nightly)